### PR TITLE
v0.1.3

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@
 ^notes.R$
 ^docs$
 ^cran-comments\.md$
+^CRAN-RELEASE$

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 Version numbers follow [Semantic Versioning](https://semver.org/).
 
+# [gendrendr 0.1.3](https://github.com/dapperstats/gendrendr/releases/tag/v0.1.3)
+*2019-11-02*
+
+### Addition of the premise regarding the sex-gender distinction
+* Premise 7 (gender and sex are both imperfect constructs and drawing distinctions between them creates unnecessary hierarchies--sex is as problematic (if not moreso) a concept than gender and holding it in any higher regard elevates out-dated medicalized views and perpetuates systematic oppressions) was added to make clear that all of the content which refers to "gender" could functionally be applied to "sex" and that using one or the other is fine, but for consistency here we're using gender. 
+
 # [gendrendr 0.1.2](https://github.com/dapperstats/gendrendr/releases/tag/v0.1.2)
 *2019-11-02*
 

--- a/R/gendr.R
+++ b/R/gendr.R
@@ -34,6 +34,7 @@
 #' @examples
 #'  \donttest{
 #'  gendr("max", "usa", "english", 1990) # produces warning
+#'  gendr() # produces warning 
 #'  gendr_warning() # produces warning
 #'  }
 #'

--- a/R/gendrendr.R
+++ b/R/gendrendr.R
@@ -2,25 +2,36 @@
 #'
 #' @description This package contains a simple set of functions designed to
 #'  highlight the inaccuracy and violence of assigning genders to others.
-#'  The premise is as follows: [1] the assignment of gender to another
-#'  in the absence of personal confirmation is an act of violence that 
-#'  perpetuates hierarchical systems of oppression and can be personally
-#'  traumatizing; [2] the assumption of the correctness of gender
-#'  assigned at birth reinforces archaic medical views and state-sanctioned
-#'  violence; [3] gender is a construct that varies over space, time, culture, 
-#'  and ethnicity, and assuming that data from one context apply to another
-#'  reinforces gendered imperialist violence and perpetuates cultural 
-#'  stereotypes; [4] of specific relevance is the fact that gender is not
-#'  a binary, and use of data that assume a gender binary reinforces that
-#'  norm, which does violence to individuals who are non-binary and erases 
-#'  cultures that embrace a diversity of genders; [5] gender cannot be 
-#'  accurately inferred from names, presentations, pronouns or other such
-#'  factors, and assuming it can and that the consequences of any failure
-#'  are trivial speaks to the devaluation of transgender, non-binary,
-#'  and gender-non-conforming life...and this is not absolved by using large
-#'  data sets and fancy statistics; and [6] if it is important for some
-#'  reason to know what someone's gender is, the only way to accurately and
-#'  definitively obtain that information is from that person.
+#'  The premise is as follows: 
+#'  \enumerate{
+#'    \item the assignment of gender to another in the absence of personal 
+#'    confirmation is an act of violence that perpetuates hierarchical 
+#'    systems of oppression and can be personally traumatizing; 
+#'    \item the assumption of the correctness of gender assigned at birth 
+#'    reinforces archaic medical views and state-sanctioned violence; 
+#'    \item gender is a construct that varies over space, time, culture, 
+#'    and ethnicity, and assuming that data from one context apply to another
+#'    reinforces gendered imperialist violence and perpetuates cultural 
+#'    stereotypes; 
+#'    \item of specific relevance is the fact that gender is not a binary, 
+#'    and use of data that assume a gender binary reinforces that
+#'    norm, which does violence to individuals who are non-binary and erases 
+#'    cultures that embrace a diversity of genders; 
+#'    \item gender cannot be accurately inferred from names, presentations,
+#'    pronouns or other such factors, and assuming it can and that the 
+#'    consequences of any failure are trivial speaks to the devaluation of 
+#'    transgender, non-binary, and gender-non-conforming life and individuals
+#'    ...and this fact is not absolved by using large data sets and fancy 
+#'    statistics; 
+#'    \item if it is important for some reason to know what someone's gender 
+#'    is, the only way to accurately and definitively obtain that information 
+#'    is from that person; and 
+#'    \item gender and sex are both imperfect constructs and drawing 
+#'    distinctions between them creates unnecessary hierarchies--sex is as 
+#'    problematic (if not moreso) a concept than gender and holding it in any 
+#'    higher regard elevates out-dated medicalized views and perpetuates 
+#'    systematic oppressions. 
+#'  }
 #' 
 #' @name gendrendr
 #'

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ The premise is as follows:
 3. gender is a construct that varies over space, time, culture, and ethnicity, and assuming that data from one context apply to another reinforces gendered imperialist violence and perpetuates cultural stereotypes; 
 4. of specific relevance is the fact that gender is not a binary, and use of data that assume a gender binary reinforces that norm, which does violence to individuals who are non-binary and erases culurues that embrace a diversity of genders; 
 5. gender cannot be accurately inferred from names, presentations, pronouns or other such factors, and assuming it can and that the consequences of any failure are trivial speaks to the devaluation of transgender, non-binary, and gender-non-conforming life...and this is not absolved by using large data sets and fancy statistics; and 
-6. if it is important for some reason to know what someone's gender is, the only way to accurately, respectfully, and definitively obtain that information is from that person.
+6. if it is important for some reason to know what someone's gender is, the only way to accurately, respectfully, and definitively obtain that information is from that person; and
+7. gender and sex are both imperfect constructs and drawing distinctions between them creates unnecessary hierarchies--sex is as problematic (if not moreso) a concept than gender and holding it in any higher regard elevates out-dated medicalized views and perpetuates systematic oppressions. 
 
 ## Status: Experimental, Active Development
 
-The `gendrendr` package is currently being actively developed and the API is evolving. 
+The `gendrendr` package is being developed and the API is evolving. *`v0.1.2`* has been submitted to CRAN.
+
 
 ## Installation
 
@@ -40,6 +42,12 @@ The main function `gendr` is used to highlight the issues associated with assign
 ```r
 library(gendrendr)
 gendr(names = "Sam", years = 1920:2020, locations = "United States", languages = "English", methods = "standard")
+```
+
+It also makes assumptions about the inputs, so you could functionally run `gendr` with default inputs:
+
+```r
+gendr()
 ```
 
 ## Authors and Contributions

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,7 +1,6 @@
 centric
 Codecov
 culurues
-debinarize
 DOI
 ender
 enders
@@ -9,8 +8,11 @@ github
 Instantiation
 LGBTQIAinSTEM
 Lifecycle
+medicalized
+moreso
 NBinSTEM
 neutrois
+oppressions
 retraumatizing
 Rstats
 spatiotemporally

--- a/man/gendr.Rd
+++ b/man/gendr.Rd
@@ -46,6 +46,7 @@ Recognizing that gender is an individual, person
 \examples{
  \donttest{
  gendr("max", "usa", "english", 1990) # produces warning
+ gendr() # produces warning 
  gendr_warning() # produces warning
  }
 

--- a/man/gendrendr.Rd
+++ b/man/gendrendr.Rd
@@ -8,24 +8,35 @@
 \description{
 This package contains a simple set of functions designed to
  highlight the inaccuracy and violence of assigning genders to others.
- The premise is as follows: [1] the assignment of gender to another
- in the absence of personal confirmation is an act of violence that 
- perpetuates hierarchical systems of oppression and can be personally
- traumatizing; [2] the assumption of the correctness of gender
- assigned at birth reinforces archaic medical views and state-sanctioned
- violence; [3] gender is a construct that varies over space, time, culture, 
- and ethnicity, and assuming that data from one context apply to another
- reinforces gendered imperialist violence and perpetuates cultural 
- stereotypes; [4] of specific relevance is the fact that gender is not
- a binary, and use of data that assume a gender binary reinforces that
- norm, which does violence to individuals who are non-binary and erases 
- cultures that embrace a diversity of genders; [5] gender cannot be 
- accurately inferred from names, presentations, pronouns or other such
- factors, and assuming it can and that the consequences of any failure
- are trivial speaks to the devaluation of transgender, non-binary,
- and gender-non-conforming life...and this is not absolved by using large
- data sets and fancy statistics; and [6] if it is important for some
- reason to know what someone's gender is, the only way to accurately and
- definitively obtain that information is from that person.
+ The premise is as follows: 
+ \enumerate{
+   \item the assignment of gender to another in the absence of personal 
+   confirmation is an act of violence that perpetuates hierarchical 
+   systems of oppression and can be personally traumatizing; 
+   \item the assumption of the correctness of gender assigned at birth 
+   reinforces archaic medical views and state-sanctioned violence; 
+   \item gender is a construct that varies over space, time, culture, 
+   and ethnicity, and assuming that data from one context apply to another
+   reinforces gendered imperialist violence and perpetuates cultural 
+   stereotypes; 
+   \item of specific relevance is the fact that gender is not a binary, 
+   and use of data that assume a gender binary reinforces that
+   norm, which does violence to individuals who are non-binary and erases 
+   cultures that embrace a diversity of genders; 
+   \item gender cannot be accurately inferred from names, presentations,
+   pronouns or other such factors, and assuming it can and that the 
+   consequences of any failure are trivial speaks to the devaluation of 
+   transgender, non-binary, and gender-non-conforming life and individuals
+   ...and this fact is not absolved by using large data sets and fancy 
+   statistics; 
+   \item if it is important for some reason to know what someone's gender 
+   is, the only way to accurately and definitively obtain that information 
+   is from that person; and 
+   \item gender and sex are both imperfect constructs and drawing 
+   distinctions between them creates unnecessary hierarchies--sex is as 
+   problematic (if not moreso) a concept than gender and holding it in any 
+   higher regard elevates out-dated medicalized views and perpetuates 
+   systematic oppressions. 
+ }
 }
 \keyword{package}


### PR DESCRIPTION
### Addition of the premise regarding the sex-gender distinction
* Premise 7 (gender and sex are both imperfect constructs and drawing distinctions between them creates unnecessary hierarchies--sex is as problematic (if not moreso) a concept than gender and holding it in any higher regard elevates out-dated medicalized views and perpetuates systematic oppressions) was added to make clear that all of the content which refers to "gender" could functionally be applied to "sex" and that using one or the other is fine, but for consistency here we're using gender.